### PR TITLE
A bit of modernisation: importlib, pathlib

### DIFF
--- a/src/resins/instrument.py
+++ b/src/resins/instrument.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections import ChainMap
 import dataclasses
-import os
+import importlib
 
 import numpy as np
 import yaml
@@ -17,8 +17,6 @@ from .models import MODELS
 if TYPE_CHECKING:
     from .models.model_base import ModelData, InstrumentModel
     from inspect import Signature
-
-INSTRUMENT_DATA_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'instrument_data')
 
 INSTRUMENT_MAP: dict[str, tuple[str, None | str]] = {
     'ARCS': ('arcs.yaml', None),
@@ -360,7 +358,7 @@ class Instrument:
                 f'"{instrument_name}" is not a valid instrument name. Only the following instruments are '
                 f'supported: {list(INSTRUMENT_MAP)}')
 
-        return os.path.join(INSTRUMENT_DATA_PATH, file_name), implied_version
+        return str(importlib.resources.files("resins.instrument_data") / file_name), implied_version
 
     def get_model_data(self, model_name: Optional[str] = None, **kwargs) -> ModelData:
         """

--- a/tests/unit_tests/test_ideal_instrument.py
+++ b/tests/unit_tests/test_ideal_instrument.py
@@ -122,7 +122,7 @@ def test_bad_width_boxcar():
     - boxcar values are normalised based on _actual_ kernel area
     """
     result, _ = _get_data("boxcar", Feature.KERNEL, case_name="bad_width_kernel")
-    assert_allclose(result, np.load(DATA_PATH / f"_get_boxcar_kernel.npy"))
+    assert_allclose(result, np.load(DATA_PATH / "_get_boxcar_kernel.npy"))
 
 
 def test_bad_width_triangle():
@@ -133,7 +133,7 @@ def test_bad_width_triangle():
     """
     result, mesh = _get_data("triangle", Feature.KERNEL, case_name="bad_width_kernel")
 
-    ref_triangle = np.load(DATA_PATH / f"_get_triangle_kernel.npy")
+    ref_triangle = np.load(DATA_PATH / "_get_triangle_kernel.npy")
 
     assert np.flatnonzero(result).tolist() == np.flatnonzero(ref_triangle).tolist()
 
@@ -151,7 +151,7 @@ def test_bad_width_trapezoid():
     """
     result, mesh = _get_data("trapezoid", Feature.PEAK, case_name="bad_width_peak")
 
-    ref = np.load(DATA_PATH / f"_get_trapezoid_peak.npy")
+    ref = np.load(DATA_PATH / "_get_trapezoid_peak.npy")
 
     # Same non-zero points
     assert np.flatnonzero(result).tolist() == np.flatnonzero(ref).tolist()

--- a/tests/unit_tests/test_instrument.py
+++ b/tests/unit_tests/test_instrument.py
@@ -3,11 +3,11 @@ import inspect
 from pathlib import Path
 import typing
 
+import numpy as np
 import pytest
 import yaml
 
 from resins import instrument as i
-from resins.models import MODELS
 from resins.models.model_base import ModelData, InstrumentModel
 
 
@@ -45,22 +45,19 @@ class MockModel(InstrumentModel):
         self.kwarg1 = kwarg1
         self.kwarg2 = kwarg2
 
-    def get_characteristics(self, energy_transfer):
-        return {}
-
     def __call__(self, frequencies, *args, **kwargs):
         return frequencies
 
-    def get_characteristics(self, omega_q):
-        return {"sigma": np.ones((len(omega_q), 1))}
+    def get_characteristics(self, points):
+        return {"sigma": np.ones((len(points), 1))}
 
-    def get_kernel(self, omega_q, mesh):
+    def get_kernel(self, points, mesh):
         return np.zeros_like(mesh)
 
-    def get_peak(self, omega_q, mesh):
+    def get_peak(self, points, mesh):
         return np.zeros_like(mesh)
 
-    def broaden(self, omega_q, data, mesh):
+    def broaden(self, points, data, mesh):
         return np.zeros_like(mesh)
 
 

--- a/tests/unit_tests/test_mixins.py
+++ b/tests/unit_tests/test_mixins.py
@@ -2,7 +2,6 @@ import os
 
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 
 from resins.models.mixins import GaussianKernel1DMixin, SimpleBroaden1DMixin
 


### PR DESCRIPTION
This is a cherry-pick and tidy-up of some useful things from #43.
The INSTRUMENT_DATA_PATH variable becomes packaging-level information accessed via importlib. This resolves some circular import issues encountered in #43.

It does slightly complicate the testing situation; for now we patch importlib.resources.files() as a fixture.
This is a bit more risky than changing our own INSTRUMENT_DATA_PATH variable; if we run into conflict with other uses for this function then we might need to reintroduce the variable. Alternatively we could consider using an environment variable so additional paths can be set at runtime.