### PR TITLE
Modernise doc dependency setup: use dependency --group

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,8 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
-          python -m pip install -r docs/requirements.txt
+          python -m pip install --group doc .
 
       - name: Build docs HTML
         working-directory: ./docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-inline_reference
-numpydoc >= 1.8.0
-packaging
-sphinx >= 8.1.3
-sphinx_parsed_codeblock @ git+https://github.com/RastislavTuranyi/sphinx_parsed_codeblock.git
-sphinx_rtd_theme >= 3.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,16 @@ dev = [
     "jaxtyping >= 0.2.34"
 ]
 
+[dependency-groups]
+doc = [
+    "inline_reference ~= 1.0",
+    "numpydoc >= 1.8.0",
+    "packaging",
+    "sphinx >= 8.1.3",
+    "sphinx_parsed_codeblock ~= 1.0",
+    "sphinx_rtd_theme >= 3.0.2",
+]
+
 [project.urls]
 Repository = "https://github.com/pace-neutrons/resins"
 


### PR DESCRIPTION
This is possible now that sphinx_parsed_codeblock is on PyPI.